### PR TITLE
[RD-38540] Enable post commit hooks on jobs for branches that are not…

### DIFF
--- a/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
+++ b/src/main/groovy/com/entagen/jenkins/JenkinsApi.groovy
@@ -92,8 +92,10 @@ class JenkinsApi {
             }
         }
 
-        if (["develop", "master"].contains(missingJob.branchName)) {
-            config = config.replaceAll("<ignorePostCommitHooks>false</ignorePostCommitHooks>", "<ignorePostCommitHooks>true</ignorePostCommitHooks>")
+        // our template jobs are now set to ignore post commit hooks:
+        // re-enable them for branches that are not managed by pipelines
+        if (!["develop", "master", "loadtesting_pre-production", "loadtesting_master"].contains(missingJob.branchName)) {
+            config = config.replaceAll("<ignorePostCommitHooks>true</ignorePostCommitHooks>", "<ignorePostCommitHooks>false</ignorePostCommitHooks>")
         }
 
         // this is in case there are other down-stream jobs that this job calls, we want to be sure we're replacing their names as well


### PR DESCRIPTION
… managed by pipelines.

* By mistake, our templates have been committed to ignore post commit hooks. This is what we wanted for branches managed by pipelines (now including loadtesting_master and loadtesting_pre-production), but not for the rest.
* We could revert the templates to their previous default, but then we may inadvertently commit the change again when solving merge conflicts. So instead keep the template setting as it is and switch it for branches that are not managed by pipelines (such jobs are not under version control).